### PR TITLE
パーマリンクをインテントで受けとった際クラッシュする不具合

### DIFF
--- a/src/net/lacolaco/smileessence/IntentRouter.java
+++ b/src/net/lacolaco/smileessence/IntentRouter.java
@@ -159,7 +159,7 @@ public class IntentRouter
     private static long getStatusID(Uri uri)
     {
         String str = "-1";
-        String[] arrayOfString = uri.toString().split("/");
+        String[] arrayOfString = uri.getPath().toString().split("/");
         for(int i = 0; i < arrayOfString.length; i++)
         {
             if(arrayOfString[i].startsWith("status"))


### PR DESCRIPTION
例えば Twitter の通知メールからリンクを開くと https://twitter.com/[screen_name]/status/[status_id]?refsrc=email のような URL になりますが、これを SmileEssence で受けとると Long.parseLong に "[status_id]?refsrc=email" が渡り、クラッシュします